### PR TITLE
feat: add support for embedded audio tracks and implement track switching functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glucose",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A minimalist video player",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1532,7 +1532,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glucose"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glucose"
-version = "3.1.0"
+version = "3.2.0"
 description = "A minimalist video player"
 edition = "2021"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -663,13 +663,39 @@ async fn remux_with_audio_track(
     video_path: String,
     audio_stream_index: i64,
 ) -> Result<String, String> {
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis();
-    let temp_path = std::env::temp_dir()
-        .join(format!("glucose_audio_{}.mkv", timestamp));
-    let temp_path_str = temp_path.to_string_lossy().to_string();
+    let mut temp_path = std::env::temp_dir();
+    let mut temp_path_str = String::new();
+    let mut file_created = false;
+    
+    for i in 0..100 {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        
+        let filename = format!("glucose_audio_{}_{}.mkv", std::process::id(), timestamp + i as u128);
+        let candidate_path = std::env::temp_dir().join(&filename);
+        
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate_path)
+        {
+            Ok(_) => {
+                temp_path = candidate_path;
+                temp_path_str = temp_path.to_string_lossy().to_string();
+                file_created = true;
+                break;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(format!("Failed to create temporary file: {}", e)),
+        }
+    }
+
+    if !file_created {
+        return Err("Failed to generate a unique temporary file path".to_string());
+    }
+
     let out = temp_path_str.clone();
 
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
@@ -691,17 +717,25 @@ async fn remux_with_audio_track(
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true)
         .spawn()
-        .map_err(|e| format!("Failed to spawn ffmpeg: {}", e))?;
+        .map_err(|e| {
+            let _ = std::fs::remove_file(&temp_path);
+            format!("Failed to spawn ffmpeg: {}", e)
+        })?;
 
     match tokio::time::timeout(TIMEOUT, child.wait_with_output()).await {
         Ok(Ok(output)) => {
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
+                let _ = tokio::fs::remove_file(&temp_path).await;
                 return Err(format!("FFmpeg remux failed: {}", stderr));
             }
         }
-        Ok(Err(e)) => return Err(format!("Failed to wait for ffmpeg: {}", e)),
+        Ok(Err(e)) => {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            return Err(format!("Failed to wait for ffmpeg: {}", e));
+        }
         Err(_) => {
+            let _ = tokio::fs::remove_file(&temp_path).await;
             return Err("ffmpeg remux timed out after 120 seconds".to_string());
         }
     }
@@ -721,8 +755,10 @@ async fn delete_temp_file(path: String) -> Result<(), String> {
     if !p.starts_with(&temp_dir) {
         return Err("Only files inside the system temp directory may be deleted".to_string());
     }
-    if p.exists() {
-        let _ = std::fs::remove_file(p);
+    if let Err(e) = std::fs::remove_file(&p) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            return Err(format!("Failed to delete temp file: {}", e));
+        }
     }
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -583,6 +583,7 @@ struct EmbeddedAudioTrack {
     language: Option<String>,
     title: Option<String>,
     channels: Option<i64>,
+    is_default: bool,
 }
 
 #[tauri::command]
@@ -595,7 +596,7 @@ async fn get_embedded_audio_tracks(
         .args([
             "-v", "error",
             "-select_streams", "a",
-            "-show_entries", "stream=index,codec_name,channels:stream_tags=language,title",
+            "-show_entries", "stream=index,codec_name,channels:stream_tags=language,title:stream_disposition=default",
             "-of", "json",
             &video_path,
         ])
@@ -638,12 +639,14 @@ async fn get_embedded_audio_tracks(
             .as_str()
             .unwrap_or("unknown")
             .to_string();
+        let is_default = stream["disposition"]["default"].as_i64().unwrap_or(0) == 1;
         tracks.push(EmbeddedAudioTrack {
             index,
             codec_name,
             language: stream["tags"]["language"].as_str().map(|s| s.to_string()),
             title: stream["tags"]["title"].as_str().map(|s| s.to_string()),
             channels: stream["channels"].as_i64(),
+            is_default,
         });
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -404,19 +404,45 @@ async fn run_with_timeout(
         .spawn()
         .map_err(|e| format!("Failed to spawn {}: {}", label, e))?;
 
-    let mut stdout = child.stdout.take().unwrap();
-    let mut stderr = child.stderr.take().unwrap();
+    let mut stdout = match child.stdout.take() {
+        Some(s) => s,
+        None => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err(format!("run_with_timeout: Failed to capture stdout for {}", label));
+        }
+    };
+
+    let mut stderr = match child.stderr.take() {
+        Some(s) => s,
+        None => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err(format!("run_with_timeout: Failed to capture stderr for {}", label));
+        }
+    };
 
     let output_result = tokio::time::timeout(timeout, async {
         let mut out = Vec::new();
         let mut err = Vec::new();
-        let (status, _, _) = tokio::join!(
+        let (status_res, out_res, err_res) = tokio::join!(
             child.wait(),
             tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut out),
             tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut err)
         );
-        std::io::Result::Ok(std::process::Output {
-            status: status?,
+        
+        if let Err(e) = status_res {
+            return Err(format!("Failed to wait for {}: {}", label, e));
+        }
+        if let Err(e) = out_res {
+            return Err(format!("Failed to read stdout for {}: {}", label, e));
+        }
+        if let Err(e) = err_res {
+            return Err(format!("Failed to read stderr for {}: {}", label, e));
+        }
+        
+        Ok(std::process::Output {
+            status: status_res.unwrap(),
             stdout: out,
             stderr: err,
         })
@@ -424,7 +450,11 @@ async fn run_with_timeout(
 
     match output_result {
         Ok(Ok(output)) => Ok(output),
-        Ok(Err(e)) => Err(format!("Failed to wait for {}: {}", label, e)),
+        Ok(Err(e)) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            Err(e)
+        }
         Err(_) => {
             let _ = child.kill().await;
             let _ = child.wait().await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -706,6 +706,14 @@ async fn remux_with_audio_track(
         return Err(format!("Invalid audio stream index: {}", audio_stream_index));
     }
 
+    let audio_tracks = get_embedded_audio_tracks(video_path.clone()).await?;
+    if !audio_tracks.iter().any(|track| track.index == audio_stream_index) {
+        return Err(format!(
+            "Stream index {} is not a valid audio track for this video",
+            audio_stream_index
+        ));
+    }
+
     let temp_dir = std::env::temp_dir();
     let mut temp_path_opt: Option<std::path::PathBuf> = None;
     

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -441,7 +441,7 @@ async fn get_embedded_subtitle_tracks(
     video_path: String,
 ) -> Result<Vec<EmbeddedSubtitleTrack>, String> {
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-    const SUPPORTED: &[&str] = &["subrip", "ass", "ssa", "webvtt", "mov_text", "srt", "text"];
+    const SUPPORTED: &[&str] = &["subrip", "ass", "ssa", "webvtt", "mov_text", "text"];
 
     let mut cmd = create_hidden_command("ffprobe");
     cmd.args([
@@ -710,60 +710,30 @@ async fn remux_with_audio_track(
     #[cfg(debug_assertions)]
     println!("Remuxing audio stream {} from: {} -> {}", audio_stream_index, video_path, temp_path_str);
 
-    let mut child = tokio::process::Command::from(create_hidden_command("ffmpeg"))
-        .args([
-            "-v", "error",
-            "-i", &video_path,
-            "-map", "0:V?",
-            "-map", &format!("0:{}", audio_stream_index),
-            "-c", "copy",
-            "-y",
-            &temp_path_str,
-        ])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .map_err(|e| {
-            let _ = std::fs::remove_file(&temp_path);
-            format!("Failed to spawn ffmpeg: {}", e)
-        })?;
+    let mut cmd = create_hidden_command("ffmpeg");
+    cmd.args([
+        "-v", "error",
+        "-i", &video_path,
+        "-map", "0:V?",
+        "-map", &format!("0:{}", audio_stream_index),
+        "-c", "copy",
+        "-y",
+        &temp_path_str,
+    ]);
 
-    let mut stdout = child.stdout.take().unwrap();
-    let mut stderr = child.stderr.take().unwrap();
-
-    let output_result = tokio::time::timeout(TIMEOUT, async {
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let (status, _, _) = tokio::join!(
-            child.wait(),
-            tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut out),
-            tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut err)
-        );
-        std::io::Result::Ok(std::process::Output {
-            status: status?,
-            stdout: out,
-            stderr: err,
-        })
-    }).await;
+    let output_result = run_with_timeout(cmd, TIMEOUT, "ffmpeg").await;
 
     match output_result {
-        Ok(Ok(output)) => {
+        Ok(output) => {
             if !output.status.success() {
                 let stderr_str = String::from_utf8_lossy(&output.stderr);
                 let _ = tokio::fs::remove_file(&temp_path).await;
                 return Err(format!("FFmpeg remux failed: {}", stderr_str));
             }
         }
-        Ok(Err(e)) => {
+        Err(e) => {
             let _ = tokio::fs::remove_file(&temp_path).await;
-            return Err(format!("Failed to wait for ffmpeg: {}", e));
-        }
-        Err(_) => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
-            let _ = tokio::fs::remove_file(&temp_path).await;
-            return Err("ffmpeg remux timed out after 120 seconds".to_string());
+            return Err(e);
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -400,77 +400,72 @@ async fn get_embedded_subtitle_tracks(
     video_path: String,
 ) -> Result<Vec<EmbeddedSubtitleTrack>, String> {
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+    const SUPPORTED: &[&str] = &["subrip", "ass", "ssa", "webvtt", "mov_text", "srt", "text"];
 
-    let task = tokio::task::spawn_blocking(move || {
-        const SUPPORTED: &[&str] =
-            &["subrip", "ass", "ssa", "webvtt", "mov_text", "srt", "text"];
+    let child = tokio::process::Command::from(create_hidden_command("ffprobe"))
+        .args([
+            "-v", "error",
+            "-select_streams", "s",
+            "-show_entries", "stream=index,codec_name:stream_tags=language,title",
+            "-of", "json",
+            &video_path,
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| format!("Failed to spawn ffprobe: {}", e))?;
 
-        let output = create_hidden_command("ffprobe")
-            .args([
-                "-v",
-                "error",
-                "-select_streams",
-                "s",
-                "-show_entries",
-                "stream=index,codec_name:stream_tags=language,title",
-                "-of",
-                "json",
-                &video_path,
-            ])
-            .output()
-            .map_err(|e| format!("Failed to run ffprobe: {}", e))?;
+    let output = match tokio::time::timeout(TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => return Err(format!("Failed to wait for ffprobe: {}", e)),
+        Err(_) => {
+            return Err("ffprobe timed out after 30 seconds".to_string());
+        }
+    };
 
-        if !output.status.success() {
-            return Ok(vec![]);
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("ffprobe failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
+        Ok(v) => v,
+        Err(e) => return Err(format!("Failed to parse ffprobe JSON: {} (stdout: {})", e, stdout)),
+    };
+
+    let streams = match parsed["streams"].as_array() {
+        Some(s) => s,
+        None => return Err("ffprobe JSON missing 'streams' array".to_string()),
+    };
+
+    let mut tracks = Vec::new();
+    for stream in streams {
+        let codec_name = stream["codec_name"]
+            .as_str()
+            .unwrap_or("unknown")
+            .to_string();
+
+        if !SUPPORTED.contains(&codec_name.as_str()) {
+            continue;
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
-            Ok(v) => v,
-            Err(_) => return Ok(vec![]),
+        let Some(index) = stream["index"].as_i64() else {
+            continue;
         };
+        tracks.push(EmbeddedSubtitleTrack {
+            index,
+            codec_name,
+            language: stream["tags"]["language"].as_str().map(|s| s.to_string()),
+            title: stream["tags"]["title"].as_str().map(|s| s.to_string()),
+        });
+    }
 
-        let streams = match parsed["streams"].as_array() {
-            Some(s) => s,
-            None => return Ok(vec![]),
-        };
+    #[cfg(debug_assertions)]
+    println!("Found {} embedded subtitle track(s) in: {}", tracks.len(), video_path);
 
-        let mut tracks = Vec::new();
-        for stream in streams {
-            let codec_name = stream["codec_name"]
-                .as_str()
-                .unwrap_or("unknown")
-                .to_string();
-
-            if !SUPPORTED.contains(&codec_name.as_str()) {
-                continue;
-            }
-
-            let Some(index) = stream["index"].as_i64() else {
-                continue;
-            };
-            tracks.push(EmbeddedSubtitleTrack {
-                index,
-                codec_name,
-                language: stream["tags"]["language"].as_str().map(|s| s.to_string()),
-                title: stream["tags"]["title"].as_str().map(|s| s.to_string()),
-            });
-        }
-
-        #[cfg(debug_assertions)]
-        println!(
-            "Found {} embedded subtitle track(s) in: {}",
-            tracks.len(),
-            video_path
-        );
-
-        Ok::<Vec<EmbeddedSubtitleTrack>, String>(tracks)
-    });
-
-    tokio::time::timeout(TIMEOUT, task)
-        .await
-        .map_err(|_| "ffprobe timed out after 30 seconds".to_string())?
-        .map_err(|e| format!("Task panicked: {}", e))?
+    Ok(tracks)
 }
 
 // Extract a single subtitle stream from a video file and return its content as
@@ -488,40 +483,37 @@ async fn extract_embedded_subtitle(
 
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-    let task = tokio::task::spawn_blocking(move || {
-        #[cfg(debug_assertions)]
-        println!(
-            "Extracting embedded subtitle stream {} from: {}",
-            stream_index, video_path
-        );
+    #[cfg(debug_assertions)]
+    println!("Extracting embedded subtitle stream {} from: {}", stream_index, video_path);
 
-        let output = create_hidden_command("ffmpeg")
-            .args([
-                "-v",
-                "error",
-                "-i",
-                &video_path,
-                "-map",
-                &format!("0:{}", stream_index),
-                "-f",
-                "srt",
-                "pipe:1",
-            ])
-            .output()
-            .map_err(|e| format!("Failed to run ffmpeg: {}", e))?;
+    let child = tokio::process::Command::from(create_hidden_command("ffmpeg"))
+        .args([
+            "-v", "error",
+            "-i", &video_path,
+            "-map", &format!("0:{}", stream_index),
+            "-f", "srt",
+            "pipe:1",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| format!("Failed to spawn ffmpeg: {}", e))?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("FFmpeg failed to extract subtitle: {}", stderr));
+    let output = match tokio::time::timeout(TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => return Err(format!("Failed to wait for ffmpeg: {}", e)),
+        Err(_) => {
+            return Err("ffmpeg timed out after 30 seconds".to_string());
         }
+    };
 
-        Ok::<String, String>(String::from_utf8_lossy(&output.stdout).to_string())
-    });
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("FFmpeg failed to extract subtitle: {}", stderr));
+    }
 
-    tokio::time::timeout(TIMEOUT, task)
-        .await
-        .map_err(|_| "ffmpeg timed out after 30 seconds".to_string())?
-        .map_err(|e| format!("Task panicked: {}", e))?
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 #[derive(Serialize, Clone)]
@@ -599,69 +591,66 @@ async fn get_embedded_audio_tracks(
 ) -> Result<Vec<EmbeddedAudioTrack>, String> {
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-    let task = tokio::task::spawn_blocking(move || {
-        let output = create_hidden_command("ffprobe")
-            .args([
-                "-v",
-                "error",
-                "-select_streams",
-                "a",
-                "-show_entries",
-                "stream=index,codec_name,channels:stream_tags=language,title",
-                "-of",
-                "json",
-                &video_path,
-            ])
-            .output()
-            .map_err(|e| format!("Failed to run ffprobe: {}", e))?;
+    let child = tokio::process::Command::from(create_hidden_command("ffprobe"))
+        .args([
+            "-v", "error",
+            "-select_streams", "a",
+            "-show_entries", "stream=index,codec_name,channels:stream_tags=language,title",
+            "-of", "json",
+            &video_path,
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| format!("Failed to spawn ffprobe: {}", e))?;
 
-        if !output.status.success() {
-            return Ok(vec![]);
+    let output = match tokio::time::timeout(TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => return Err(format!("Failed to wait for ffprobe: {}", e)),
+        Err(_) => {
+            return Err("ffprobe timed out after 30 seconds".to_string());
         }
+    };
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
-            Ok(v) => v,
-            Err(_) => return Ok(vec![]),
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("ffprobe failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
+        Ok(v) => v,
+        Err(e) => return Err(format!("Failed to parse ffprobe JSON: {} (stdout: {})", e, stdout)),
+    };
+
+    let streams = match parsed["streams"].as_array() {
+        Some(s) => s,
+        None => return Err("ffprobe JSON missing 'streams' array".to_string()),
+    };
+
+    let mut tracks = Vec::new();
+    for stream in streams {
+        let Some(index) = stream["index"].as_i64() else {
+            continue;
         };
+        let codec_name = stream["codec_name"]
+            .as_str()
+            .unwrap_or("unknown")
+            .to_string();
+        tracks.push(EmbeddedAudioTrack {
+            index,
+            codec_name,
+            language: stream["tags"]["language"].as_str().map(|s| s.to_string()),
+            title: stream["tags"]["title"].as_str().map(|s| s.to_string()),
+            channels: stream["channels"].as_i64(),
+        });
+    }
 
-        let streams = match parsed["streams"].as_array() {
-            Some(s) => s,
-            None => return Ok(vec![]),
-        };
+    #[cfg(debug_assertions)]
+    println!("Found {} embedded audio track(s) in: {}", tracks.len(), video_path);
 
-        let mut tracks = Vec::new();
-        for stream in streams {
-            let Some(index) = stream["index"].as_i64() else {
-                continue;
-            };
-            let codec_name = stream["codec_name"]
-                .as_str()
-                .unwrap_or("unknown")
-                .to_string();
-            tracks.push(EmbeddedAudioTrack {
-                index,
-                codec_name,
-                language: stream["tags"]["language"].as_str().map(|s| s.to_string()),
-                title: stream["tags"]["title"].as_str().map(|s| s.to_string()),
-                channels: stream["channels"].as_i64(),
-            });
-        }
-
-        #[cfg(debug_assertions)]
-        println!(
-            "Found {} embedded audio track(s) in: {}",
-            tracks.len(),
-            video_path
-        );
-
-        Ok::<Vec<EmbeddedAudioTrack>, String>(tracks)
-    });
-
-    tokio::time::timeout(TIMEOUT, task)
-        .await
-        .map_err(|_| "ffprobe timed out after 30 seconds".to_string())?
-        .map_err(|e| format!("Task panicked: {}", e))?
+    Ok(tracks)
 }
 
 // Re-mux the video retaining only the selected audio stream (stream copy — no
@@ -682,38 +671,37 @@ async fn remux_with_audio_track(
 
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
-    let task = tokio::task::spawn_blocking(move || {
-        #[cfg(debug_assertions)]
-        println!(
-            "Remuxing audio stream {} from: {} -> {}",
-            audio_stream_index, video_path, temp_path_str
-        );
+    #[cfg(debug_assertions)]
+    println!("Remuxing audio stream {} from: {} -> {}", audio_stream_index, video_path, temp_path_str);
 
-        let output = create_hidden_command("ffmpeg")
-            .args([
-                "-v", "error",
-                "-i", &video_path,
-                "-map", "0:v",
-                "-map", &format!("0:{}", audio_stream_index),
-                "-c", "copy",
-                "-y",
-                &temp_path_str,
-            ])
-            .output()
-            .map_err(|e| format!("Failed to run ffmpeg: {}", e))?;
+    let child = tokio::process::Command::from(create_hidden_command("ffmpeg"))
+        .args([
+            "-v", "error",
+            "-i", &video_path,
+            "-map", "0:v",
+            "-map", &format!("0:{}", audio_stream_index),
+            "-c", "copy",
+            "-y",
+            &temp_path_str,
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| format!("Failed to spawn ffmpeg: {}", e))?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("FFmpeg remux failed: {}", stderr));
+    match tokio::time::timeout(TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(output)) => {
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                return Err(format!("FFmpeg remux failed: {}", stderr));
+            }
         }
-
-        Ok::<(), String>(())
-    });
-
-    tokio::time::timeout(TIMEOUT, task)
-        .await
-        .map_err(|_| "ffmpeg remux timed out after 120 seconds".to_string())?
-        .map_err(|e| format!("Task panicked: {}", e))??;
+        Ok(Err(e)) => return Err(format!("Failed to wait for ffmpeg: {}", e)),
+        Err(_) => {
+            return Err("ffmpeg remux timed out after 120 seconds".to_string());
+        }
+    }
 
     Ok(out)
 }
@@ -721,8 +709,8 @@ async fn remux_with_audio_track(
 // Delete a file that must reside in the system temp directory.
 #[tauri::command]
 async fn delete_temp_file(path: String) -> Result<(), String> {
-    let temp_dir = std::env::temp_dir();
-    let p = std::path::Path::new(&path);
+    let temp_dir = std::env::temp_dir().canonicalize().map_err(|e| e.to_string())?;
+    let p = std::path::Path::new(&path).canonicalize().map_err(|e| e.to_string())?;
     if !p.starts_with(&temp_dir) {
         return Err("Only files inside the system temp directory may be deleted".to_string());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -584,6 +584,154 @@ struct EmbeddedSubtitleTrack {
     title: Option<String>,
 }
 
+#[derive(Serialize, Clone)]
+struct EmbeddedAudioTrack {
+    index: i64,
+    codec_name: String,
+    language: Option<String>,
+    title: Option<String>,
+    channels: Option<i64>,
+}
+
+#[tauri::command]
+async fn get_embedded_audio_tracks(
+    video_path: String,
+) -> Result<Vec<EmbeddedAudioTrack>, String> {
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+    let task = tokio::task::spawn_blocking(move || {
+        let output = create_hidden_command("ffprobe")
+            .args([
+                "-v",
+                "error",
+                "-select_streams",
+                "a",
+                "-show_entries",
+                "stream=index,codec_name,channels:stream_tags=language,title",
+                "-of",
+                "json",
+                &video_path,
+            ])
+            .output()
+            .map_err(|e| format!("Failed to run ffprobe: {}", e))?;
+
+        if !output.status.success() {
+            return Ok(vec![]);
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
+            Ok(v) => v,
+            Err(_) => return Ok(vec![]),
+        };
+
+        let streams = match parsed["streams"].as_array() {
+            Some(s) => s,
+            None => return Ok(vec![]),
+        };
+
+        let mut tracks = Vec::new();
+        for stream in streams {
+            let Some(index) = stream["index"].as_i64() else {
+                continue;
+            };
+            let codec_name = stream["codec_name"]
+                .as_str()
+                .unwrap_or("unknown")
+                .to_string();
+            tracks.push(EmbeddedAudioTrack {
+                index,
+                codec_name,
+                language: stream["tags"]["language"].as_str().map(|s| s.to_string()),
+                title: stream["tags"]["title"].as_str().map(|s| s.to_string()),
+                channels: stream["channels"].as_i64(),
+            });
+        }
+
+        #[cfg(debug_assertions)]
+        println!(
+            "Found {} embedded audio track(s) in: {}",
+            tracks.len(),
+            video_path
+        );
+
+        Ok::<Vec<EmbeddedAudioTrack>, String>(tracks)
+    });
+
+    tokio::time::timeout(TIMEOUT, task)
+        .await
+        .map_err(|_| "ffprobe timed out after 30 seconds".to_string())?
+        .map_err(|e| format!("Task panicked: {}", e))?
+}
+
+// Re-mux the video retaining only the selected audio stream (stream copy — no
+// re-encoding).  Returns the path to a temp file that the frontend can load.
+#[tauri::command]
+async fn remux_with_audio_track(
+    video_path: String,
+    audio_stream_index: i64,
+) -> Result<String, String> {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let temp_path = std::env::temp_dir()
+        .join(format!("glucose_audio_{}.mkv", timestamp));
+    let temp_path_str = temp_path.to_string_lossy().to_string();
+    let out = temp_path_str.clone();
+
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+    let task = tokio::task::spawn_blocking(move || {
+        #[cfg(debug_assertions)]
+        println!(
+            "Remuxing audio stream {} from: {} -> {}",
+            audio_stream_index, video_path, temp_path_str
+        );
+
+        let output = create_hidden_command("ffmpeg")
+            .args([
+                "-v", "error",
+                "-i", &video_path,
+                "-map", "0:v",
+                "-map", &format!("0:{}", audio_stream_index),
+                "-c", "copy",
+                "-y",
+                &temp_path_str,
+            ])
+            .output()
+            .map_err(|e| format!("Failed to run ffmpeg: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("FFmpeg remux failed: {}", stderr));
+        }
+
+        Ok::<(), String>(())
+    });
+
+    tokio::time::timeout(TIMEOUT, task)
+        .await
+        .map_err(|_| "ffmpeg remux timed out after 120 seconds".to_string())?
+        .map_err(|e| format!("Task panicked: {}", e))??;
+
+    Ok(out)
+}
+
+// Delete a file that must reside in the system temp directory.
+#[tauri::command]
+async fn delete_temp_file(path: String) -> Result<(), String> {
+    let temp_dir = std::env::temp_dir();
+    let p = std::path::Path::new(&path);
+    if !p.starts_with(&temp_dir) {
+        return Err("Only files inside the system temp directory may be deleted".to_string());
+    }
+    if p.exists() {
+        std::fs::remove_file(p).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
 // Get video duration using FFmpeg
 // Note: Caller should verify ffprobe is available before calling this
 fn get_video_duration(video_path: &str) -> Option<f64> {
@@ -1763,6 +1911,9 @@ pub fn run() {
             find_subtitle_for_video,
             get_embedded_subtitle_tracks,
             extract_embedded_subtitle,
+            get_embedded_audio_tracks,
+            remux_with_audio_track,
+            delete_temp_file,
             generate_subtitles,
             check_ffmpeg_installed,
             check_installed_models,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -392,34 +392,22 @@ fn find_subtitle_for_video(video_path: String) -> Result<Option<String>, String>
     Ok(None)
 }
 
-// Return the list of text-based subtitle streams embedded in a video file.
-// Bitmap formats (PGS, VobSub, DVB) are silently skipped because they cannot
-// be converted to a text format that the browser can render.
-#[tauri::command]
-async fn get_embedded_subtitle_tracks(
-    video_path: String,
-) -> Result<Vec<EmbeddedSubtitleTrack>, String> {
-    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-    const SUPPORTED: &[&str] = &["subrip", "ass", "ssa", "webvtt", "mov_text", "srt", "text"];
-
-    let mut child = tokio::process::Command::from(create_hidden_command("ffprobe"))
-        .args([
-            "-v", "error",
-            "-select_streams", "s",
-            "-show_entries", "stream=index,codec_name:stream_tags=language,title",
-            "-of", "json",
-            &video_path,
-        ])
+async fn run_with_timeout(
+    cmd: std::process::Command,
+    timeout: std::time::Duration,
+    label: &str,
+) -> Result<std::process::Output, String> {
+    let mut child = tokio::process::Command::from(cmd)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true)
         .spawn()
-        .map_err(|e| format!("Failed to spawn ffprobe: {}", e))?;
+        .map_err(|e| format!("Failed to spawn {}: {}", label, e))?;
 
     let mut stdout = child.stdout.take().unwrap();
     let mut stderr = child.stderr.take().unwrap();
 
-    let output_result = tokio::time::timeout(TIMEOUT, async {
+    let output_result = tokio::time::timeout(timeout, async {
         let mut out = Vec::new();
         let mut err = Vec::new();
         let (status, _, _) = tokio::join!(
@@ -434,15 +422,37 @@ async fn get_embedded_subtitle_tracks(
         })
     }).await;
 
-    let output = match output_result {
-        Ok(Ok(output)) => output,
-        Ok(Err(e)) => return Err(format!("Failed to wait for ffprobe: {}", e)),
+    match output_result {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(e)) => Err(format!("Failed to wait for {}: {}", label, e)),
         Err(_) => {
             let _ = child.kill().await;
             let _ = child.wait().await;
-            return Err("ffprobe timed out after 30 seconds".to_string());
+            Err(format!("{} timed out after {} seconds", label, timeout.as_secs()))
         }
-    };
+    }
+}
+
+// Return the list of text-based subtitle streams embedded in a video file.
+// Bitmap formats (PGS, VobSub, DVB) are silently skipped because they cannot
+// be converted to a text format that the browser can render.
+#[tauri::command]
+async fn get_embedded_subtitle_tracks(
+    video_path: String,
+) -> Result<Vec<EmbeddedSubtitleTrack>, String> {
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+    const SUPPORTED: &[&str] = &["subrip", "ass", "ssa", "webvtt", "mov_text", "srt", "text"];
+
+    let mut cmd = create_hidden_command("ffprobe");
+    cmd.args([
+        "-v", "error",
+        "-select_streams", "s",
+        "-show_entries", "stream=index,codec_name:stream_tags=language,title",
+        "-of", "json",
+        &video_path,
+    ]);
+
+    let output = run_with_timeout(cmd, TIMEOUT, "ffprobe").await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -506,47 +516,16 @@ async fn extract_embedded_subtitle(
     #[cfg(debug_assertions)]
     println!("Extracting embedded subtitle stream {} from: {}", stream_index, video_path);
 
-    let mut child = tokio::process::Command::from(create_hidden_command("ffmpeg"))
-        .args([
-            "-v", "error",
-            "-i", &video_path,
-            "-map", &format!("0:{}", stream_index),
-            "-f", "srt",
-            "pipe:1",
-        ])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .map_err(|e| format!("Failed to spawn ffmpeg: {}", e))?;
+    let mut cmd = create_hidden_command("ffmpeg");
+    cmd.args([
+        "-v", "error",
+        "-i", &video_path,
+        "-map", &format!("0:{}", stream_index),
+        "-f", "srt",
+        "pipe:1",
+    ]);
 
-    let mut stdout = child.stdout.take().unwrap();
-    let mut stderr = child.stderr.take().unwrap();
-
-    let output_result = tokio::time::timeout(TIMEOUT, async {
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let (status, _, _) = tokio::join!(
-            child.wait(),
-            tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut out),
-            tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut err)
-        );
-        std::io::Result::Ok(std::process::Output {
-            status: status?,
-            stdout: out,
-            stderr: err,
-        })
-    }).await;
-
-    let output = match output_result {
-        Ok(Ok(output)) => output,
-        Ok(Err(e)) => return Err(format!("Failed to wait for ffmpeg: {}", e)),
-        Err(_) => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
-            return Err("ffmpeg timed out after 30 seconds".to_string());
-        }
-    };
+    let output = run_with_timeout(cmd, TIMEOUT, "ffmpeg").await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -632,47 +611,16 @@ async fn get_embedded_audio_tracks(
 ) -> Result<Vec<EmbeddedAudioTrack>, String> {
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-    let mut child = tokio::process::Command::from(create_hidden_command("ffprobe"))
-        .args([
-            "-v", "error",
-            "-select_streams", "a",
-            "-show_entries", "stream=index,codec_name,channels:stream_tags=language,title:stream_disposition=default",
-            "-of", "json",
-            &video_path,
-        ])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .map_err(|e| format!("Failed to spawn ffprobe: {}", e))?;
+    let mut cmd = create_hidden_command("ffprobe");
+    cmd.args([
+        "-v", "error",
+        "-select_streams", "a",
+        "-show_entries", "stream=index,codec_name,channels:stream_tags=language,title:stream_disposition=default",
+        "-of", "json",
+        &video_path,
+    ]);
 
-    let mut stdout = child.stdout.take().unwrap();
-    let mut stderr = child.stderr.take().unwrap();
-
-    let output_result = tokio::time::timeout(TIMEOUT, async {
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let (status, _, _) = tokio::join!(
-            child.wait(),
-            tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut out),
-            tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut err)
-        );
-        std::io::Result::Ok(std::process::Output {
-            status: status?,
-            stdout: out,
-            stderr: err,
-        })
-    }).await;
-
-    let output = match output_result {
-        Ok(Ok(output)) => output,
-        Ok(Err(e)) => return Err(format!("Failed to wait for ffprobe: {}", e)),
-        Err(_) => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
-            return Err("ffprobe timed out after 30 seconds".to_string());
-        }
-    };
+    let output = run_with_timeout(cmd, TIMEOUT, "ffprobe").await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -727,9 +675,8 @@ async fn remux_with_audio_track(
         return Err(format!("Invalid audio stream index: {}", audio_stream_index));
     }
 
-    let mut temp_path = std::env::temp_dir();
-    let mut temp_path_str = String::new();
-    let mut file_created = false;
+    let temp_dir = std::env::temp_dir();
+    let mut temp_path_opt: Option<std::path::PathBuf> = None;
     
     for i in 0..100 {
         let timestamp = std::time::SystemTime::now()
@@ -738,7 +685,7 @@ async fn remux_with_audio_track(
             .as_nanos();
         
         let filename = format!("glucose_audio_{}_{}.mkv", std::process::id(), timestamp + i as u128);
-        let candidate_path = std::env::temp_dir().join(&filename);
+        let candidate_path = temp_dir.join(&filename);
         
         match std::fs::OpenOptions::new()
             .write(true)
@@ -746,9 +693,7 @@ async fn remux_with_audio_track(
             .open(&candidate_path)
         {
             Ok(_) => {
-                temp_path = candidate_path;
-                temp_path_str = temp_path.to_string_lossy().to_string();
-                file_created = true;
+                temp_path_opt = Some(candidate_path);
                 break;
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
@@ -756,10 +701,8 @@ async fn remux_with_audio_track(
         }
     }
 
-    if !file_created {
-        return Err("Failed to generate a unique temporary file path".to_string());
-    }
-
+    let temp_path = temp_path_opt.ok_or_else(|| "Failed to generate a unique temporary file path".to_string())?;
+    let temp_path_str = temp_path.to_string_lossy().to_string();
     let out = temp_path_str.clone();
 
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
@@ -831,11 +774,15 @@ async fn remux_with_audio_track(
 #[tauri::command]
 async fn delete_temp_file(path: String) -> Result<(), String> {
     let target = std::path::Path::new(&path);
-    if !target.exists() {
-        return Ok(());
-    }
+    
+    let p = match target.canonicalize() {
+        Ok(p) => p,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e.to_string()),
+    };
+
     let temp_dir = std::env::temp_dir().canonicalize().map_err(|e| e.to_string())?;
-    let p = target.canonicalize().map_err(|e| e.to_string())?;
+    
     if !p.starts_with(&temp_dir) {
         return Err("Only files inside the system temp directory may be deleted".to_string());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -431,9 +431,10 @@ async fn run_with_timeout(
             tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut err)
         );
         
-        if let Err(e) = status_res {
-            return Err(format!("Failed to wait for {}: {}", label, e));
-        }
+        let status = match status_res {
+            Ok(s) => s,
+            Err(e) => return Err(format!("Failed to wait for {}: {}", label, e)),
+        };
         if let Err(e) = out_res {
             return Err(format!("Failed to read stdout for {}: {}", label, e));
         }
@@ -442,7 +443,7 @@ async fn run_with_timeout(
         }
         
         Ok(std::process::Output {
-            status: status_res.unwrap(),
+            status,
             stdout: out,
             stderr: err,
         })
@@ -792,7 +793,7 @@ async fn delete_temp_file(path: String) -> Result<(), String> {
     if !file_name.starts_with("glucose_audio_") || !file_name.ends_with(".mkv") {
         return Err("Only glucose_audio_*.mkv files may be deleted".to_string());
     }
-    if let Err(e) = std::fs::remove_file(&p) {
+    if let Err(e) = tokio::fs::remove_file(&p).await {
         if e.kind() != std::io::ErrorKind::NotFound {
             return Err(format!("Failed to delete temp file: {}", e));
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -712,13 +712,17 @@ async fn remux_with_audio_track(
 // Delete a file that must reside in the system temp directory.
 #[tauri::command]
 async fn delete_temp_file(path: String) -> Result<(), String> {
+    let target = std::path::Path::new(&path);
+    if !target.exists() {
+        return Ok(());
+    }
     let temp_dir = std::env::temp_dir().canonicalize().map_err(|e| e.to_string())?;
-    let p = std::path::Path::new(&path).canonicalize().map_err(|e| e.to_string())?;
+    let p = target.canonicalize().map_err(|e| e.to_string())?;
     if !p.starts_with(&temp_dir) {
         return Err("Only files inside the system temp directory may be deleted".to_string());
     }
     if p.exists() {
-        std::fs::remove_file(p).map_err(|e| e.to_string())?;
+        let _ = std::fs::remove_file(p);
     }
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -402,7 +402,7 @@ async fn get_embedded_subtitle_tracks(
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
     const SUPPORTED: &[&str] = &["subrip", "ass", "ssa", "webvtt", "mov_text", "srt", "text"];
 
-    let child = tokio::process::Command::from(create_hidden_command("ffprobe"))
+    let mut child = tokio::process::Command::from(create_hidden_command("ffprobe"))
         .args([
             "-v", "error",
             "-select_streams", "s",
@@ -416,10 +416,30 @@ async fn get_embedded_subtitle_tracks(
         .spawn()
         .map_err(|e| format!("Failed to spawn ffprobe: {}", e))?;
 
-    let output = match tokio::time::timeout(TIMEOUT, child.wait_with_output()).await {
+    let mut stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+
+    let output_result = tokio::time::timeout(TIMEOUT, async {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let (status, _, _) = tokio::join!(
+            child.wait(),
+            tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut out),
+            tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut err)
+        );
+        std::io::Result::Ok(std::process::Output {
+            status: status?,
+            stdout: out,
+            stderr: err,
+        })
+    }).await;
+
+    let output = match output_result {
         Ok(Ok(output)) => output,
         Ok(Err(e)) => return Err(format!("Failed to wait for ffprobe: {}", e)),
         Err(_) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
             return Err("ffprobe timed out after 30 seconds".to_string());
         }
     };
@@ -486,7 +506,7 @@ async fn extract_embedded_subtitle(
     #[cfg(debug_assertions)]
     println!("Extracting embedded subtitle stream {} from: {}", stream_index, video_path);
 
-    let child = tokio::process::Command::from(create_hidden_command("ffmpeg"))
+    let mut child = tokio::process::Command::from(create_hidden_command("ffmpeg"))
         .args([
             "-v", "error",
             "-i", &video_path,
@@ -500,10 +520,30 @@ async fn extract_embedded_subtitle(
         .spawn()
         .map_err(|e| format!("Failed to spawn ffmpeg: {}", e))?;
 
-    let output = match tokio::time::timeout(TIMEOUT, child.wait_with_output()).await {
+    let mut stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+
+    let output_result = tokio::time::timeout(TIMEOUT, async {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let (status, _, _) = tokio::join!(
+            child.wait(),
+            tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut out),
+            tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut err)
+        );
+        std::io::Result::Ok(std::process::Output {
+            status: status?,
+            stdout: out,
+            stderr: err,
+        })
+    }).await;
+
+    let output = match output_result {
         Ok(Ok(output)) => output,
         Ok(Err(e)) => return Err(format!("Failed to wait for ffmpeg: {}", e)),
         Err(_) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
             return Err("ffmpeg timed out after 30 seconds".to_string());
         }
     };
@@ -592,7 +632,7 @@ async fn get_embedded_audio_tracks(
 ) -> Result<Vec<EmbeddedAudioTrack>, String> {
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-    let child = tokio::process::Command::from(create_hidden_command("ffprobe"))
+    let mut child = tokio::process::Command::from(create_hidden_command("ffprobe"))
         .args([
             "-v", "error",
             "-select_streams", "a",
@@ -606,10 +646,30 @@ async fn get_embedded_audio_tracks(
         .spawn()
         .map_err(|e| format!("Failed to spawn ffprobe: {}", e))?;
 
-    let output = match tokio::time::timeout(TIMEOUT, child.wait_with_output()).await {
+    let mut stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+
+    let output_result = tokio::time::timeout(TIMEOUT, async {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let (status, _, _) = tokio::join!(
+            child.wait(),
+            tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut out),
+            tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut err)
+        );
+        std::io::Result::Ok(std::process::Output {
+            status: status?,
+            stdout: out,
+            stderr: err,
+        })
+    }).await;
+
+    let output = match output_result {
         Ok(Ok(output)) => output,
         Ok(Err(e)) => return Err(format!("Failed to wait for ffprobe: {}", e)),
         Err(_) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
             return Err("ffprobe timed out after 30 seconds".to_string());
         }
     };
@@ -663,6 +723,10 @@ async fn remux_with_audio_track(
     video_path: String,
     audio_stream_index: i64,
 ) -> Result<String, String> {
+    if audio_stream_index < 0 {
+        return Err(format!("Invalid audio stream index: {}", audio_stream_index));
+    }
+
     let mut temp_path = std::env::temp_dir();
     let mut temp_path_str = String::new();
     let mut file_created = false;
@@ -703,11 +767,11 @@ async fn remux_with_audio_track(
     #[cfg(debug_assertions)]
     println!("Remuxing audio stream {} from: {} -> {}", audio_stream_index, video_path, temp_path_str);
 
-    let child = tokio::process::Command::from(create_hidden_command("ffmpeg"))
+    let mut child = tokio::process::Command::from(create_hidden_command("ffmpeg"))
         .args([
             "-v", "error",
             "-i", &video_path,
-            "-map", "0:v",
+            "-map", "0:V?",
             "-map", &format!("0:{}", audio_stream_index),
             "-c", "copy",
             "-y",
@@ -722,12 +786,30 @@ async fn remux_with_audio_track(
             format!("Failed to spawn ffmpeg: {}", e)
         })?;
 
-    match tokio::time::timeout(TIMEOUT, child.wait_with_output()).await {
+    let mut stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+
+    let output_result = tokio::time::timeout(TIMEOUT, async {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let (status, _, _) = tokio::join!(
+            child.wait(),
+            tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut out),
+            tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut err)
+        );
+        std::io::Result::Ok(std::process::Output {
+            status: status?,
+            stdout: out,
+            stderr: err,
+        })
+    }).await;
+
+    match output_result {
         Ok(Ok(output)) => {
             if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stderr_str = String::from_utf8_lossy(&output.stderr);
                 let _ = tokio::fs::remove_file(&temp_path).await;
-                return Err(format!("FFmpeg remux failed: {}", stderr));
+                return Err(format!("FFmpeg remux failed: {}", stderr_str));
             }
         }
         Ok(Err(e)) => {
@@ -735,6 +817,8 @@ async fn remux_with_audio_track(
             return Err(format!("Failed to wait for ffmpeg: {}", e));
         }
         Err(_) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
             let _ = tokio::fs::remove_file(&temp_path).await;
             return Err("ffmpeg remux timed out after 120 seconds".to_string());
         }
@@ -754,6 +838,12 @@ async fn delete_temp_file(path: String) -> Result<(), String> {
     let p = target.canonicalize().map_err(|e| e.to_string())?;
     if !p.starts_with(&temp_dir) {
         return Err("Only files inside the system temp directory may be deleted".to_string());
+    }
+    let file_name = p.file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "Invalid file name".to_string())?;
+    if !file_name.starts_with("glucose_audio_") || !file_name.ends_with(".mkv") {
+        return Err("Only glucose_audio_*.mkv files may be deleted".to_string());
     }
     if let Err(e) = std::fs::remove_file(&p) {
         if e.kind() != std::io::ErrorKind::NotFound {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,7 +11,7 @@
   "app": {
     "windows": [
       {
-        "title": "glucose",
+        "title": "Glucose",
         "width": 1280,
         "height": 720,
         "minWidth": 800,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,6 +23,7 @@
     Bug,
     Globe,
     Shield,
+    ShieldAlert,
     ScrollText,
     Users,
     Star,
@@ -665,6 +666,24 @@
                         )}
                     >
                       <Bug size={14} /> Report Bug
+                    </Button>
+                  </div>
+                </div>
+
+                <div class="settings-item">
+                  <div class="settings-item-label">
+                    <div class="settings-item-title">Report Subtitles</div>
+                    <div class="settings-item-desc">
+                      Report inappropriate AI-generated subtitles
+                    </div>
+                  </div>
+                  <div class="settings-item-action">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onclick={() => openUrl("mailto:support@glucose.media?subject=Report%20Inappropriate%20AI%20Subtitles")}
+                    >
+                      <ShieldAlert size={14} /> Report
                     </Button>
                   </div>
                 </div>

--- a/src/routes/player/[videoPath]/+page.svelte
+++ b/src/routes/player/[videoPath]/+page.svelte
@@ -96,8 +96,10 @@
   let embeddedAudioTracks = $state<EmbeddedAudioTrack[]>([]);
   let selectedAudioTrackIndex = $state<number | null>(null);
   let audioRemuxPath = $state<string | null>(null);
+  let pendingRemuxCleanupPaths = $state<string[]>([]);
   let isRemuxingAudio = $state(false);
   let pendingSeekTime = $state<number | null>(null);
+  let pendingPaused = $state<boolean | null>(null);
   let isGeneratingSubtitles = $state(false);
   let generationProgress = $state(0);
   let generationMessage = $state("");
@@ -303,11 +305,15 @@
           console.error("Failed to revoke subtitle blob URL:", err);
         }
       }
-      // Clean up audio remux temp file
+      // Clean up audio remux temp files
       if (audioRemuxPath) {
         invoke("delete_temp_file", { path: audioRemuxPath }).catch(() => {});
         audioRemuxPath = null;
       }
+      for (const path of pendingRemuxCleanupPaths) {
+        invoke("delete_temp_file", { path }).catch(() => {});
+      }
+      pendingRemuxCleanupPaths = [];
       // Unregister event listeners
       for (const un of unsubs) {
         try {
@@ -926,7 +932,8 @@
 
   async function handleLoadedMetadata() {
     if (!videoElement) return;
-    const wasPaused = videoElement.paused;
+    const wasPaused = pendingPaused !== null ? pendingPaused : videoElement.paused;
+    pendingPaused = null;
     duration = videoElement.duration;
 
     // When switching audio tracks, jump straight to the saved position.
@@ -1098,7 +1105,6 @@
     if (selectedAudioTrackIndex === track.index && audioRemuxPath !== null) return;
 
     isRemuxingAudio = true;
-    const savedTime = videoElement.currentTime;
 
     try {
       const tempPath = await invoke<string>("remux_with_audio_track", {
@@ -1106,14 +1112,29 @@
         audioStreamIndex: track.index,
       });
 
+      const preSwitchTime = videoElement.currentTime;
+      const preSwitchPaused = videoElement.paused;
+
       if (audioRemuxPath) {
-        invoke("delete_temp_file", { path: audioRemuxPath }).catch(() => {});
+        pendingRemuxCleanupPaths.push(audioRemuxPath);
       }
 
       audioRemuxPath = tempPath;
       selectedAudioTrackIndex = track.index;
-      pendingSeekTime = savedTime;
+      pendingSeekTime = preSwitchTime;
+      pendingPaused = preSwitchPaused;
       videoSrc = convertFileSrc(tempPath);
+
+      // Attempt cleanup of pending files
+      for (const path of [...pendingRemuxCleanupPaths]) {
+        try {
+          await invoke("delete_temp_file", { path });
+          pendingRemuxCleanupPaths = pendingRemuxCleanupPaths.filter(p => p !== path);
+        } catch (e) {
+          console.warn("Failed to delete remux temp file, will retry later:", path, e);
+        }
+      }
+
     } catch (err) {
       console.error("Failed to remux audio track:", err);
       alert("Failed to switch audio track: " + err);

--- a/src/routes/player/[videoPath]/+page.svelte
+++ b/src/routes/player/[videoPath]/+page.svelte
@@ -92,6 +92,7 @@
     language: string | null;
     title: string | null;
     channels: number | null;
+    is_default: boolean;
   }
   let embeddedAudioTracks = $state<EmbeddedAudioTrack[]>([]);
   let selectedAudioTrackIndex = $state<number | null>(null);
@@ -213,7 +214,8 @@
           if (disposed) return;
           embeddedAudioTracks = audioTracks;
           if (audioTracks.length > 0) {
-            selectedAudioTrackIndex = audioTracks[0].index;
+            const defaultTrack = audioTracks.find((t) => t.is_default);
+            selectedAudioTrackIndex = defaultTrack ? defaultTrack.index : audioTracks[0].index;
           }
         } catch (err) {
           console.log("Embedded audio track detection failed:", err);
@@ -1102,15 +1104,21 @@
 
   async function switchEmbeddedAudioTrack(track: EmbeddedAudioTrack) {
     if (!videoElement || !data.videoPath) return;
-    if (selectedAudioTrackIndex === track.index && audioRemuxPath !== null) return;
+    if (selectedAudioTrackIndex === track.index) return;
 
     isRemuxingAudio = true;
+    const currentVideoPathAtCall = data.videoPath;
 
     try {
       const tempPath = await invoke<string>("remux_with_audio_track", {
         videoPath: data.videoPath,
         audioStreamIndex: track.index,
       });
+
+      if (!videoElement || data.videoPath !== currentVideoPathAtCall) {
+        invoke("delete_temp_file", { path: tempPath }).catch(() => {});
+        return;
+      }
 
       const preSwitchTime = videoElement.currentTime;
       const preSwitchPaused = videoElement.paused;
@@ -1125,15 +1133,18 @@
       pendingPaused = preSwitchPaused;
       videoSrc = convertFileSrc(tempPath);
 
-      // Attempt cleanup of pending files
-      for (const path of [...pendingRemuxCleanupPaths]) {
-        try {
-          await invoke("delete_temp_file", { path });
-          pendingRemuxCleanupPaths = pendingRemuxCleanupPaths.filter(p => p !== path);
-        } catch (e) {
-          console.warn("Failed to delete remux temp file, will retry later:", path, e);
-        }
-      }
+      // Attempt cleanup of pending files in the background without awaiting sequentially
+      const pathsToClean = [...pendingRemuxCleanupPaths];
+      pendingRemuxCleanupPaths = [];
+      
+      Promise.allSettled(
+        pathsToClean.map(path => 
+          invoke("delete_temp_file", { path }).catch((e) => {
+            console.warn("Failed to delete remux temp file, will retry later:", path, e);
+            pendingRemuxCleanupPaths.push(path);
+          })
+        )
+      );
 
     } catch (err) {
       console.error("Failed to remux audio track:", err);

--- a/src/routes/player/[videoPath]/+page.svelte
+++ b/src/routes/player/[videoPath]/+page.svelte
@@ -926,6 +926,7 @@
 
   async function handleLoadedMetadata() {
     if (!videoElement) return;
+    const wasPaused = videoElement.paused;
     duration = videoElement.duration;
 
     // When switching audio tracks, jump straight to the saved position.
@@ -965,14 +966,19 @@
     // Set up Web Audio API for volume boost, then auto-play
     setupAudioContext();
     if (audioCtx?.state === "suspended") audioCtx.resume();
-    videoElement.play().catch((err) => {
-      console.log("Auto-play prevented:", err);
-    });
-    // Start background video
-    if (backgroundVideo) {
-      backgroundVideo.play().catch(() => {});
+    
+    if (!wasPaused) {
+      videoElement.play().catch((err) => {
+        console.log("Auto-play prevented:", err);
+      });
+      // Start background video
+      if (backgroundVideo) {
+        backgroundVideo.play().catch(() => {});
+      }
+      isPlaying = true;
+    } else {
+      isPlaying = false;
     }
-    isPlaying = true;
 
     // Show controls briefly when video loads
     showControls = true;
@@ -1095,15 +1101,14 @@
     const savedTime = videoElement.currentTime;
 
     try {
-      if (audioRemuxPath) {
-        invoke("delete_temp_file", { path: audioRemuxPath }).catch(() => {});
-        audioRemuxPath = null;
-      }
-
       const tempPath = await invoke<string>("remux_with_audio_track", {
         videoPath: data.videoPath,
         audioStreamIndex: track.index,
       });
+
+      if (audioRemuxPath) {
+        invoke("delete_temp_file", { path: audioRemuxPath }).catch(() => {});
+      }
 
       audioRemuxPath = tempPath;
       selectedAudioTrackIndex = track.index;

--- a/src/routes/player/[videoPath]/+page.svelte
+++ b/src/routes/player/[videoPath]/+page.svelte
@@ -84,6 +84,20 @@
   }
   let embeddedSubtitleTracks = $state<EmbeddedSubtitleTrack[]>([]);
   let selectedEmbeddedLanguage = $state('en');
+
+  // Embedded audio tracks
+  interface EmbeddedAudioTrack {
+    index: number;
+    codec_name: string;
+    language: string | null;
+    title: string | null;
+    channels: number | null;
+  }
+  let embeddedAudioTracks = $state<EmbeddedAudioTrack[]>([]);
+  let selectedAudioTrackIndex = $state<number | null>(null);
+  let audioRemuxPath = $state<string | null>(null);
+  let isRemuxingAudio = $state(false);
+  let pendingSeekTime = $state<number | null>(null);
   let isGeneratingSubtitles = $state(false);
   let generationProgress = $state(0);
   let generationMessage = $state("");
@@ -188,6 +202,20 @@
         } catch (err) {
           console.log("Embedded subtitle detection failed:", err);
         }
+
+        try {
+          const audioTracks = await invoke<EmbeddedAudioTrack[]>(
+            "get_embedded_audio_tracks",
+            { videoPath: data.videoPath },
+          );
+          if (disposed) return;
+          embeddedAudioTracks = audioTracks;
+          if (audioTracks.length > 0) {
+            selectedAudioTrackIndex = audioTracks[0].index;
+          }
+        } catch (err) {
+          console.log("Embedded audio track detection failed:", err);
+        }
       }
     })();
 
@@ -274,6 +302,11 @@
         } catch (err) {
           console.error("Failed to revoke subtitle blob URL:", err);
         }
+      }
+      // Clean up audio remux temp file
+      if (audioRemuxPath) {
+        invoke("delete_temp_file", { path: audioRemuxPath }).catch(() => {});
+        audioRemuxPath = null;
       }
       // Unregister event listeners
       for (const un of unsubs) {
@@ -895,10 +928,13 @@
     if (!videoElement) return;
     duration = videoElement.duration;
 
-    // Restore watch progress first, then play — avoids jumping from 0 to the
-    // saved position after playback has already started.
+    // When switching audio tracks, jump straight to the saved position.
+    // Otherwise restore watch progress from the database.
     const videoPathBeforeAwait = currentVideoPath;
-    if (currentVideoPath) {
+    if (pendingSeekTime !== null) {
+      videoElement.currentTime = pendingSeekTime;
+      pendingSeekTime = null;
+    } else if (currentVideoPath) {
       await invoke<WatchProgress | null>("get_watch_progress", {
         videoPath: currentVideoPath,
       })
@@ -1033,6 +1069,51 @@
       audioDevices = outputDevices;
     } catch (err) {
       console.error("Failed to load audio devices:", err);
+    }
+  }
+
+  function formatAudioTrackLabel(track: EmbeddedAudioTrack): string {
+    if (track.title) return track.title;
+    if (track.language) return track.language.toUpperCase();
+    return `Track ${track.index}`;
+  }
+
+  function formatChannelLabel(channels: number | null): string {
+    if (channels === null) return "";
+    if (channels === 1) return "Mono";
+    if (channels === 2) return "Stereo";
+    if (channels === 6) return "5.1";
+    if (channels === 8) return "7.1";
+    return `${channels}ch`;
+  }
+
+  async function switchEmbeddedAudioTrack(track: EmbeddedAudioTrack) {
+    if (!videoElement || !data.videoPath) return;
+    if (selectedAudioTrackIndex === track.index && audioRemuxPath !== null) return;
+
+    isRemuxingAudio = true;
+    const savedTime = videoElement.currentTime;
+
+    try {
+      if (audioRemuxPath) {
+        invoke("delete_temp_file", { path: audioRemuxPath }).catch(() => {});
+        audioRemuxPath = null;
+      }
+
+      const tempPath = await invoke<string>("remux_with_audio_track", {
+        videoPath: data.videoPath,
+        audioStreamIndex: track.index,
+      });
+
+      audioRemuxPath = tempPath;
+      selectedAudioTrackIndex = track.index;
+      pendingSeekTime = savedTime;
+      videoSrc = convertFileSrc(tempPath);
+    } catch (err) {
+      console.error("Failed to remux audio track:", err);
+      alert("Failed to switch audio track: " + err);
+    } finally {
+      isRemuxingAudio = false;
     }
   }
 
@@ -1450,6 +1531,27 @@
                     <Volume2 size={16} />
                   {/if}
                 </button>
+                {#if embeddedAudioTracks.length > 1}
+                  <div class="audio-tracks-divider"></div>
+                  <div class="audio-tracks-label">
+                    {isRemuxingAudio ? "Switching…" : "Audio Track"}
+                  </div>
+                  {#each embeddedAudioTracks as track}
+                    <button
+                      class="audio-track-option"
+                      class:selected={selectedAudioTrackIndex === track.index}
+                      disabled={isRemuxingAudio}
+                      onclick={() => switchEmbeddedAudioTrack(track)}
+                    >
+                      <span class="audio-track-name">{formatAudioTrackLabel(track)}</span>
+                      {#if track.channels}
+                        <span class="audio-track-desc">{formatChannelLabel(track.channels)} · {track.codec_name.toUpperCase()}</span>
+                      {:else}
+                        <span class="audio-track-desc">{track.codec_name.toUpperCase()}</span>
+                      {/if}
+                    </button>
+                  {/each}
+                {/if}
               </div>
             {/if}
           </div>
@@ -2269,6 +2371,58 @@
     background: rgba(255, 0, 0, 0.2);
     border-color: rgba(255, 0, 0, 0.3);
     color: #ff5555;
+  }
+
+  .audio-tracks-divider {
+    width: 100%;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.1);
+    margin: 0.25rem 0;
+  }
+
+  .audio-tracks-label {
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: rgba(255, 255, 255, 0.4);
+    padding: 0 0.25rem;
+    align-self: flex-start;
+  }
+
+  .audio-track-option {
+    width: 100%;
+    padding: 0.4rem 0.5rem;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    color: rgba(255, 255, 255, 0.85);
+    text-align: left;
+    cursor: pointer;
+    font-size: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    transition: all 0.15s ease;
+  }
+
+  .audio-track-option:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .audio-track-option.selected {
+    border-color: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .audio-track-name {
+    font-weight: 600;
+    color: #fff;
+  }
+
+  .audio-track-desc {
+    font-size: 0.65rem;
+    color: rgba(255, 255, 255, 0.5);
   }
 
   /* Subtitle styling */


### PR DESCRIPTION

- Added detection and display of embedded audio tracks.
- Enabled audio track switching with FFmpeg-based re-muxing and seamless playback state restoration.
- Introduced UI elements for selecting audio tracks in the video player.
- Updated version to 3.2.0 in `Cargo.toml`, `Cargo.lock`, and `package.json`.
- Minor branding update: Changed window title to "Glucose" in `tauri.conf.json`.